### PR TITLE
Add contributing doc, add comments to ocsp_status.go

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+## Adding a New Lint or Verification
+
+To be filled out once modular linting PR gets approved and checked in

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 OCSP Response Linter is a command line tool for fetching as well as linting and verifying OCSP responses.
 
+**This is not an officially supported Google product.**
+
 ## Lints and Verifications Sources
 
 The lints and verifications implemented come primarily from [Apple's OCSP Lints and Test Cases](bug1588001.bmoattachments.org/attachment.cgi?id=9160540) and IETF standards set out in [RFC 6960](tools.ietf.org/html/rfc6960)
@@ -27,9 +29,3 @@ Example usage to lint/verify a locally saved OCSP Response
 ```bash
 ./ocsp_status -in ocsp_response
 ```
-
-## Adding a New Lint or Verification
-
-To be filled out, haven't settled on the design yet
-
-**This is not an officially supported Google product.**


### PR DESCRIPTION
I also decided that the `parseResponse` function was not necessary (just a shell around a library function)